### PR TITLE
UI: always validate parameters on stop

### DIFF
--- a/root/usr/share/nethesis/NethServer/Module/Don/Stop.php
+++ b/root/usr/share/nethesis/NethServer/Module/Don/Stop.php
@@ -37,8 +37,8 @@ class Stop extends \Nethgui\Controller\AbstractController
             }
         });
         parent::initialize();
-        $this->declareParameter('SystemId', FALSE, array('configuration', 'don', 'SystemId'));
-        $this->declareParameter('SessionId', FALSE, $sessionIdAdapter);
+        $this->declareParameter('SystemId', Validate::ANYTHING, array('configuration', 'don', 'SystemId'));
+        $this->declareParameter('SessionId', Validate::ANYTHING, $sessionIdAdapter);
     }
 
     public function process()


### PR DESCRIPTION
Avoid validation error: valid_forced_failure

Fix bug introduced by #5 