### PR TITLE
UI: hide server identifier

### DIFF
--- a/root/usr/share/nethesis/NethServer/Module/Don.php
+++ b/root/usr/share/nethesis/NethServer/Module/Don.php
@@ -43,10 +43,4 @@ class Don extends \Nethgui\Controller\CompositeController
             $this->addChild(new Don\Start());
         }
     }
-    public function prepareView(\Nethgui\View\ViewInterface $view)
-    {
-        parent::prepareView($view);
-        $systemid = $this->getPlatform()->getDatabase('configuration')->getProp('don', 'SystemId');
-        $view['SystemId'] = $systemid;
-    }
 }

--- a/root/usr/share/nethesis/NethServer/Template/Don/Start.php
+++ b/root/usr/share/nethesis/NethServer/Template/Don/Start.php
@@ -6,8 +6,6 @@ if ( $view['SystemId'] ) {
     
     echo '<div class="notification don_description noconfig"><p>'.$T('Start_description').'</p></div>';
 
-    echo "<div><span class='don_label'>".$T('SystemId_label').":</span>"; echo $view->textLabel('SystemId'); echo " </div>";
-    echo "<div class='don_spacer'></div>";
     echo "<div><span class='don_label'>".$T('ServerName_label').":</span>"; echo $view->textLabel('ServerName'); echo " </div>";
     echo "<div class='don_spacer'></div>";
     echo $view->buttonList()


### PR DESCRIPTION
Prevent lusers error who are not reading the text and
confuse server identifier with remote support identifier.